### PR TITLE
Add pagination support for Microsoft Graph API calls in SharePoint reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
@@ -1,12 +1,12 @@
 # CHANGELOG
 
-## [0.7.1] - 2026-02-15
+## [0.8.0] - 2026-02-15
 
 ### Added
 
 - Add pagination support for all Microsoft Graph API calls to handle large result sets
 
-## [0.6.0] - 2026-01-28
+## [0.7.0] - 2026-01-28
 
 ### Added
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.7.1] - 2026-02-15
+
+### Added
+
+- Add pagination support for all Microsoft Graph API calls to handle large result sets
+
 ## [0.6.0] - 2026-01-28
 
 ### Added

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -324,7 +324,7 @@ class SharePointReader(
         drives = self._get_all_items_with_pagination(self._drive_id_endpoint)
 
         if drives:
-            if len(drives) > 0 and self.drive_name is not None:
+            if self.drive_name is not None:
                 for drive in drives:
                     if drive["name"].lower() == self.drive_name.lower():
                         return drive["id"]

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -214,6 +214,30 @@ class SharePointReader(
         )
         return self._send_request_with_retry(request)
 
+    def _get_all_items_with_pagination(self, endpoint: str) -> List[Dict[str, Any]]:
+        """
+        Generic helper to fetch all items from a Graph API endpoint with pagination support.
+        Automatically follows @odata.nextLink to retrieve all pages.
+
+        Args:
+            endpoint (str): The initial Graph API endpoint URL
+
+        Returns:
+            List[Dict[str, Any]]: All items from all pages combined
+
+        """
+        all_items = []
+        next_link = endpoint
+
+        while next_link:
+            response = self._send_get_with_retry(next_link)
+            response_json = response.json()
+            items = response_json.get("value", [])
+            all_items.extend(items)
+            next_link = response_json.get("@odata.nextLink")
+
+        return all_items
+
     def _get_site_id_with_host_name(
         self, access_token, sharepoint_site_name: Optional[str]
     ) -> str:
@@ -296,28 +320,25 @@ class SharePointReader(
 
         self._drive_id_endpoint = f"https://graph.microsoft.com/v1.0/sites/{self._site_id_with_host_name}/drives"
 
-        response = self._send_get_with_retry(self._drive_id_endpoint)
-        json_response = response.json()
+        # Use generic pagination helper to get all drives
+        drives = self._get_all_items_with_pagination(self._drive_id_endpoint)
 
-        if response.status_code == 200 and "value" in json_response:
-            if len(json_response["value"]) > 0 and self.drive_name is not None:
-                for drive in json_response["value"]:
+        if drives:
+            if len(drives) > 0 and self.drive_name is not None:
+                for drive in drives:
                     if drive["name"].lower() == self.drive_name.lower():
                         return drive["id"]
                 raise ValueError(f"The specified drive {self.drive_name} is not found.")
 
-            if len(json_response["value"]) > 0 and "id" in json_response["value"][0]:
-                return json_response["value"][0]["id"]
+            if len(drives) > 0 and "id" in drives[0]:
+                return drives[0]["id"]
             else:
                 raise ValueError(
                     "Error occurred while fetching the drives for the sharepoint site."
                 )
         else:
-            error_message = json_response.get("error_description") or json_response.get(
-                "error"
-            )
-            logger.error("Error retrieving drive ID: %s", json_response["error"])
-            raise ValueError(f"Error retrieving drive ID: {error_message}")
+            logger.error("No drives found for the SharePoint site.")
+            raise ValueError("No drives found for the SharePoint site.")
 
     def _get_sharepoint_folder_id(self, folder_path: str) -> str:
         """
@@ -709,8 +730,8 @@ class SharePointReader(
         folder_contents_endpoint = (
             f"{self._drive_id_endpoint}/{self._drive_id}/items/{folder_id}/children"
         )
-        response = self._send_get_with_retry(folder_contents_endpoint)
-        items = response.json().get("value", [])
+        # Use generic pagination helper to get all items
+        items = self._get_all_items_with_pagination(folder_contents_endpoint)
         file_paths = []
         for item in items:
             if "folder" in item and recursive:
@@ -738,10 +759,11 @@ class SharePointReader(
         drive_contents_endpoint = (
             f"{self._drive_id_endpoint}/{self._drive_id}/root/children"
         )
-        response = self._send_get_with_retry(drive_contents_endpoint)
-        items = response.json().get("value", [])
-
         file_paths = []
+
+        # Use generic pagination helper to get all items
+        items = self._get_all_items_with_pagination(drive_contents_endpoint)
+
         for item in items:
             if "folder" in item:
                 # Append folder path
@@ -959,8 +981,8 @@ class SharePointReader(
         """
         endpoint = f"https://graph.microsoft.com/v1.0/sites/{site_id}/lists?$filter=displayName eq 'Site Pages'"
         try:
-            response = self._send_get_with_retry(endpoint)
-            lists = response.json().get("value", [])
+            # Use generic pagination helper to get all lists
+            lists = self._get_all_items_with_pagination(endpoint)
             if not lists:
                 logger.error("Site Pages list not found for site %s", site_id)
                 raise ValueError("Site Pages list not found")
@@ -983,9 +1005,12 @@ class SharePointReader(
         try:
             list_id = self.get_site_pages_list_id(site_id)
             endpoint = f"https://graph.microsoft.com/v1.0/sites/{site_id}/lists/{list_id}/items?expand=fields(select=FileLeafRef,CanvasContent1)"
-            response = self._send_get_with_retry(endpoint)
-            items = response.json().get("value", [])
+
             pages = []
+
+            # Use generic pagination helper to get all items
+            items = self._get_all_items_with_pagination(endpoint)
+
             for item in items:
                 fields = item.get("fields", {})
                 page_id = item.get("id")
@@ -1019,8 +1044,11 @@ class SharePointReader(
         try:
             list_id = self.get_site_pages_list_id(site_id)
             endpoint = f"https://graph.microsoft.com/v1.0/sites/{site_id}/lists/{list_id}/items?expand=fields"
-            response = self._send_get_with_retry(endpoint)
-            items = response.json().get("value", [])
+
+            # Use generic pagination helper to get all items
+            items = self._get_all_items_with_pagination(endpoint)
+
+            # Search for matching page
             matches = [
                 item
                 for item in items
@@ -1028,6 +1056,7 @@ class SharePointReader(
             ]
             if matches:
                 return matches[0].get("id")
+
             return None
         except Exception as e:
             logger.error(

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.7.1"
+version = "0.8.0"
 description = "llama-index readers microsoft_sharepoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.7.0"
+version = "0.7.1"
 description = "llama-index readers microsoft_sharepoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR adds automatic pagination support for all Microsoft Graph API calls in the SharePoint reader to ensure complete data retrieval when SharePoint sites have large numbers of drives, files, folders, or pages.

## Motivation

Without pagination, the reader only retrieves the first page of results (default limit is typically 200 items). This causes issues for:
- SharePoint sites with many drives
- Folders with hundreds of files  
- Sites with numerous pages

## Changes

- Added `_get_all_items_with_pagination()` helper method that automatically follows `@odata.nextLink` to retrieve all pages from Graph API responses
- Applied pagination to all Graph API calls:
  - Drive listing (`_get_drive_id()`)
  - Folder contents (`_list_folder_contents()`)
  - Drive root contents (`_get_drive_content_paths()`)
  - Site Pages list retrieval (`get_site_pages_list_id()`)
  - Site Pages items (`get_all_site_pages()`)
  - Page search by name (`get_page_id_by_name()`)
- Updated CHANGELOG.md with version 0.7.1
- Added comprehensive unit tests for pagination functionality

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (existing package update)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
